### PR TITLE
fix: Improved Portainer authentication jwt expiry handling

### DIFF
--- a/PatchPanda.Web/Helpers/JwtHelper.cs
+++ b/PatchPanda.Web/Helpers/JwtHelper.cs
@@ -1,0 +1,36 @@
+﻿using System.Text.Json;
+
+namespace PatchPanda.Web.Helpers;
+
+public class JwtHelper
+{
+    public static DateTime? GetJwtExpiry(string jwt)
+    {
+        try
+        {
+            var parts = jwt.Split('.');
+            if (parts.Length < 2) return null;
+
+            var payload = parts[1];
+            var base64 = payload.Replace('-', '+').Replace('_', '/');
+            switch (base64.Length % 4)
+            {
+                case 2: base64 += "=="; break;
+                case 3: base64 += "="; break;
+            }
+
+            var bytes = Convert.FromBase64String(base64);
+            using var doc = JsonDocument.Parse(bytes);
+            if (doc.RootElement.TryGetProperty("exp", out var expElement) && expElement.TryGetInt64(out var exp))
+            {
+                return DateTimeOffset.FromUnixTimeSeconds(exp).UtcDateTime;
+            }
+        }
+        catch
+        {
+            return null;
+        }
+
+        return null;
+    }
+}

--- a/PatchPanda.Web/Services/PortainerService.cs
+++ b/PatchPanda.Web/Services/PortainerService.cs
@@ -67,6 +67,8 @@ public class PortainerService : IPortainerService
             return;
         }
 
+        _logger.LogInformation("Using username and password to authenticate with Portainer...");
+
         var payload = JsonSerializer.Serialize(new { username = _username, password = _password });
         var resp = await _httpClient.PostAsync(
             "/api/auth",
@@ -94,10 +96,11 @@ public class PortainerService : IPortainerService
                 "Bearer",
                 _jwt
             );
-            _jwtExpiry = DateTime.UtcNow.AddHours(8);
+            _jwtExpiry = JwtHelper.GetJwtExpiry(_jwt) ?? DateTime.UtcNow.AddHours(8);
+            _logger.LogInformation("Portainer authentication successful.");
         }
         else
-            _logger.LogWarning("Failed parsing Portainer auth response");
+            _logger.LogWarning("Failed parsing Portainer auth response.");
     }
 
     private async Task<PortainerStackDto?> GetStack(string stackName)


### PR DESCRIPTION
Session lifetime is configurable in Portainer under Settings → Authentication → Configuration → Session lifetime. Using a longer session lifetime does not affect the program. However, using a shorter session lifetime of less than 8 hours will result in PatchPanda assuming the jwt is valid and trying to request resources with it. This results in multiple exceptions and Portainer compose stacks not being updated.

This PR improves this behavior by retrieving the expiry from the jwt token itself instead of assuming it to be 8 hours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented JWT token expiry extraction functionality to improve authentication token management and accuracy.

* **Improvements**
  * Portainer service authentication now dynamically retrieves and uses the actual JWT token expiry time instead of relying on a hardcoded 8-hour duration, providing more precise token lifecycle management.
  * Enhanced authentication logging with additional diagnostic messages for improved troubleshooting and visibility during service authentication processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->