### PR TITLE
feat: Exponential backoff for automatic update failures

### DIFF
--- a/PatchPanda.Web/Services/UpdateService.cs
+++ b/PatchPanda.Web/Services/UpdateService.cs
@@ -237,7 +237,7 @@ public class UpdateService
 
             if (consecutiveFailures > 0)
             {
-                var backoffHours = Math.Pow(2, consecutiveFailures);
+                var backoffHours = Math.Min(Math.Pow(2, consecutiveFailures), 72); // Cap at 72 hours (3 days)
                 var nextAllowedUpdate = lastFailureTime.AddHours(backoffHours);
 
                 if (DateTime.UtcNow < nextAllowedUpdate)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-update resilience by adding an exponential backoff after consecutive failures.
  * Prevents queuing repeated update attempts when recent failures indicate likely continued failure.
  * Backoff grows with each consecutive failure (capped at 72 hours) so retries occur after increasing intervals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->