### PR TITLE
fix: Don't change github regex if override is active

### DIFF
--- a/PatchPanda.Web/Services/DockerService.cs
+++ b/PatchPanda.Web/Services/DockerService.cs
@@ -287,7 +287,10 @@ public class DockerService
                     existingContainer.Version = runningContainer.Version;
                     existingContainer.TargetImage = runningContainer.TargetImage;
                     existingContainer.Regex = runningContainer.Regex;
-                    if (existingContainer.OverrideGitHubRepo is null)
+                    if (
+                        existingContainer.OverrideGitHubRepo is null
+                        || existingContainer.GitHubVersionRegex is null
+                    )
                         existingContainer.GitHubVersionRegex = runningContainer.GitHubVersionRegex;
 
                     if (runningContainer.Version is not null)

--- a/PatchPanda.Web/Services/DockerService.cs
+++ b/PatchPanda.Web/Services/DockerService.cs
@@ -287,7 +287,8 @@ public class DockerService
                     existingContainer.Version = runningContainer.Version;
                     existingContainer.TargetImage = runningContainer.TargetImage;
                     existingContainer.Regex = runningContainer.Regex;
-                    existingContainer.GitHubVersionRegex = runningContainer.GitHubVersionRegex;
+                    if (existingContainer.OverrideGitHubRepo is null)
+                        existingContainer.GitHubVersionRegex = runningContainer.GitHubVersionRegex;
 
                     if (runningContainer.Version is not null)
                         existingContainer.NewerVersions.RemoveAll(x =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where container configuration settings were being unconditionally overwritten during reset operations. Version settings now respect existing override preferences, preventing inadvertent loss of configured values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->