### PR TITLE
feat: support dot in repo owner and repo name

### DIFF
--- a/PatchPanda.Units/Helpers/ParsingHelperTests.cs
+++ b/PatchPanda.Units/Helpers/ParsingHelperTests.cs
@@ -170,7 +170,7 @@ public class ParsingHelperTests
         var response = new ContainerListResponse
         {
             Image =
-                $"ghcr.io/{TestData.GITHUB_OWNER}/{TestData.GITHUB_REPO}:1.0,https://github.com/{TestData.OWNER_B}/{TestData.REPO_B}"
+                $"ghcr.io/{TestData.GITHUB_OWNER}/{TestData.GITHUB_REPO}:1.0,https://github.com/{TestData.OWNER_B}/{TestData.REPO_B}",
         };
 
         var sharedRelease = CreateRelease(TestData.RELEASE_TAG, TestData.GITHUB_URL);
@@ -208,6 +208,45 @@ public class ParsingHelperTests
         Assert.Null(container.SecondaryGitHubRepos);
         Assert.Equal(
             VersionHelper.BuildRegexFromVersion(TestData.RELEASE_TAG),
+            container.GitHubVersionRegex
+        );
+    }
+
+    [Fact]
+    public async Task SetGitHubRepo_SetsRepo_WhenRepositoryContainsDot()
+    {
+        var image = $"ghcr.io/{TestData.DOT_OWNER}/{TestData.DOT_REPO}:{TestData.VERSION}";
+        var repoUrl = $"https://github.com/{TestData.DOT_OWNER}/{TestData.DOT_REPO}";
+
+        var stack = Helper.GetTestStack(TestData.VERSION, null, image);
+        var container = stack.Apps[0];
+
+        var response = new ContainerListResponse { Image = image };
+
+        var release = CreateRelease(TestData.NEW_VERSION, repoUrl);
+
+        var versionServiceMock = new Mock<IVersionService>();
+
+        versionServiceMock
+            .Setup(vs =>
+                vs.GetVersions(
+                    It.Is<Tuple<string, string>>(t =>
+                        t.Item1 == TestData.DOT_OWNER && t.Item2 == TestData.DOT_REPO
+                    )
+                )
+            )
+            .ReturnsAsync([release]);
+
+        var logger = new Mock<ILogger>().Object;
+
+        await container.SetGitHubRepo(response, versionServiceMock.Object, logger);
+
+        Assert.Equal(
+            new Tuple<string, string>(TestData.DOT_OWNER, TestData.DOT_REPO),
+            container.GitHubRepo
+        );
+        Assert.Equal(
+            VersionHelper.BuildRegexFromVersion(TestData.NEW_VERSION),
             container.GitHubVersionRegex
         );
     }

--- a/PatchPanda.Units/TestData.cs
+++ b/PatchPanda.Units/TestData.cs
@@ -28,4 +28,7 @@ public static class TestData
     public const string RELEASE_TAG_A = "v1.0.0";
     public const string RELEASE_TAG_B = "v2.0.0";
     public const string ALPINE_IMAGE = "alpine:3.16";
+
+    public const string DOT_OWNER = "dgtlmoon";
+    public const string DOT_REPO = "changedetection.io";
 }

--- a/PatchPanda.Web/Helpers/ParsingHelper.cs
+++ b/PatchPanda.Web/Helpers/ParsingHelper.cs
@@ -21,15 +21,15 @@ public static class ParsingHelper
 
         var githubMatches = Regex.Matches(
             fullResponse,
-            @"https://github.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)"
+            @"https://github.com\/([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+)"
         );
 
         var ghcrMatches = Regex.Matches(
             fullResponse,
-            @"ghcr.io\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)"
+            @"ghcr.io\/([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+)"
         );
 
-        var imageMatches = Regex.Matches(response.Image, @"([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+):");
+        var imageMatches = Regex.Matches(response.Image, @"([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+):");
 
         Dictionary<Tuple<string, string>, IReadOnlyList<Octokit.Release>> versionCounts = [];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added support for parsing GitHub repositories with dots (.) in the owner or repository name, enabling proper version detection for such repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->