### PR TITLE
Post update hook

### DIFF
--- a/PatchPanda.Units/GlobalUsings.cs
+++ b/PatchPanda.Units/GlobalUsings.cs
@@ -5,5 +5,6 @@ global using Moq;
 global using PatchPanda.Web.Db;
 global using PatchPanda.Web.Entities;
 global using PatchPanda.Web.Helpers;
+global using PatchPanda.Services;
 global using PatchPanda.Web.Services;
 global using PatchPanda.Web.Services.Interfaces;

--- a/PatchPanda.Units/Services/UpdateServiceTests.cs
+++ b/PatchPanda.Units/Services/UpdateServiceTests.cs
@@ -50,7 +50,8 @@ public class UpdateServiceTests
             _portainerService.Object,
             _versionService.Object,
             _jobRegistry,
-            _notificationService.Object
+            _notificationService.Object,
+            new HookService(new Mock<ILogger<HookService>>().Object)
         );
     }
 

--- a/PatchPanda.Web/Entities/Container.cs
+++ b/PatchPanda.Web/Entities/Container.cs
@@ -26,6 +26,8 @@ public class Container : AbstractEntity
 
     public int? MultiContainerAppId { get; set; }
 
+    public string? PostUpdateHook { get; set; }
+
     public virtual MultiContainerApp? MultiContainerApp { get; set; }
 
     public bool IsSecondary { get; set; }

--- a/PatchPanda.Web/Migrations/20260323223243_AddPostUpdateHook.Designer.cs
+++ b/PatchPanda.Web/Migrations/20260323223243_AddPostUpdateHook.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PatchPanda.Web.Db;
 
@@ -10,9 +11,11 @@ using PatchPanda.Web.Db;
 namespace PatchPanda.Web.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20260323223243_AddPostUpdateHook")]
+    partial class AddPostUpdateHook
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.10");

--- a/PatchPanda.Web/Migrations/20260323223243_AddPostUpdateHook.cs
+++ b/PatchPanda.Web/Migrations/20260323223243_AddPostUpdateHook.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PatchPanda.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPostUpdateHook : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PostUpdateHook",
+                table: "Containers",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PostUpdateHook",
+                table: "Containers");
+        }
+    }
+}

--- a/PatchPanda.Web/Program.cs
+++ b/PatchPanda.Web/Program.cs
@@ -1,5 +1,6 @@
 using PatchPanda.Web.Components;
 using PatchPanda.Web.Services.Background;
+using PatchPanda.Services;
 
 namespace PatchPanda.Web;
 
@@ -27,6 +28,7 @@ public sealed partial class Program
         builder.Services.AddSingleton<JobQueue>();
         builder.Services.AddHostedService<VersionCheckHostedService>();
         builder.Services.AddHostedService<UpdateBackgroundService>();
+        builder.Services.AddSingleton<HookService>();
 
         var baseUrl = builder.Configuration.GetValue<string?>(Constants.VariableKeys.BASE_URL);
 

--- a/PatchPanda.Web/Program.cs
+++ b/PatchPanda.Web/Program.cs
@@ -90,3 +90,4 @@ public sealed partial class Program
         await portainerService.ValidateAccessTokenAsync();
     }
 }
+

--- a/PatchPanda.Web/Services/DockerService.cs
+++ b/PatchPanda.Web/Services/DockerService.cs
@@ -2,7 +2,6 @@ using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using Docker.DotNet;
-using PatchPanda.Services;
 
 namespace PatchPanda.Web.Services;
 
@@ -15,15 +14,13 @@ public class DockerService
     private readonly IVersionService _versionService;
     private readonly IPortainerService _portainerService;
     private readonly IFileService _fileService;
-    private readonly HookService _hookService;
 
     public DockerService(
         ILogger<DockerService> logger,
         IDbContextFactory<DataContext> dbContextFactory,
         IVersionService versionService,
         IPortainerService portainerService,
-        IFileService fileService,
-        HookService hookService
+        IFileService fileService
     )
     {
         DockerSocket = "unix:///var/run/docker.sock";
@@ -43,7 +40,6 @@ public class DockerService
         _versionService = versionService;
         _portainerService = portainerService;
         _fileService = fileService;
-        _hookService = hookService;
     }
 
     /// <summary>

--- a/PatchPanda.Web/Services/DockerService.cs
+++ b/PatchPanda.Web/Services/DockerService.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using Docker.DotNet;
+using PatchPanda.Services;
 
 namespace PatchPanda.Web.Services;
 
@@ -14,13 +15,15 @@ public class DockerService
     private readonly IVersionService _versionService;
     private readonly IPortainerService _portainerService;
     private readonly IFileService _fileService;
+    private readonly HookService _hookService;
 
     public DockerService(
         ILogger<DockerService> logger,
         IDbContextFactory<DataContext> dbContextFactory,
         IVersionService versionService,
         IPortainerService portainerService,
-        IFileService fileService
+        IFileService fileService,
+        HookService hookService
     )
     {
         DockerSocket = "unix:///var/run/docker.sock";
@@ -40,6 +43,7 @@ public class DockerService
         _versionService = versionService;
         _portainerService = portainerService;
         _fileService = fileService;
+        _hookService = hookService;
     }
 
     /// <summary>
@@ -173,6 +177,12 @@ public class DockerService
                     Regex = string.Empty,
                     Stack = existingStack,
                     StackId = existingStack.Id,
+                    PostUpdateHook = container.Labels.TryGetValue(
+                        "patchpanda.hook.post_update",
+                        out var hookPath
+                    )
+                        ? hookPath
+                        : null,
                 };
 
                 if (

--- a/PatchPanda.Web/Services/DockerService.cs
+++ b/PatchPanda.Web/Services/DockerService.cs
@@ -301,6 +301,7 @@ public class DockerService
                     existingContainer.Version = runningContainer.Version;
                     existingContainer.TargetImage = runningContainer.TargetImage;
                     existingContainer.Regex = runningContainer.Regex;
+                    existingContainer.PostUpdateHook = runningContainer.PostUpdateHook;
                     if (
                         existingContainer.OverrideGitHubRepo is null
                         || existingContainer.GitHubVersionRegex is null

--- a/PatchPanda.Web/Services/HookServices.cs
+++ b/PatchPanda.Web/Services/HookServices.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+
+namespace PatchPanda.Services;
+
+public class HookService
+{
+    private readonly ILogger<HookService> _logger;
+
+    public HookService(ILogger<HookService> logger) => _logger = logger;
+
+    public async Task ExecuteHookAsync(string scriptPath, string composePath, string name, string oldVer, string newVer)
+    {
+        if (string.IsNullOrEmpty(scriptPath) || !File.Exists(scriptPath)) return;
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "/bin/bash",
+            Arguments = $"-c \"{scriptPath}\"",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        // Exporting your requested variables
+        startInfo.EnvironmentVariables["PP_PROJECT_DIR"] = Path.GetDirectoryName(composePath) ?? string.Empty;
+        startInfo.EnvironmentVariables["PP_NAME"] = name;
+        startInfo.EnvironmentVariables["PP_OLD_VERSION"] = oldVer;
+        startInfo.EnvironmentVariables["PP_NEW_VERSION"] = newVer;
+        startInfo.EnvironmentVariables["PP_UPDATE_TIME"] = DateTime.UtcNow.ToString("o");
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+        await process.WaitForExitAsync();
+    }
+}

--- a/PatchPanda.Web/Services/HookServices.cs
+++ b/PatchPanda.Web/Services/HookServices.cs
@@ -10,7 +10,19 @@ public class HookService
 
     public async Task ExecuteHookAsync(string scriptPath, string composePath, string name, string oldVer, string newVer)
     {
-        if (string.IsNullOrEmpty(scriptPath) || !File.Exists(scriptPath)) return;
+        if (string.IsNullOrEmpty(scriptPath))
+        {
+            _logger.LogWarning("Hook script path is empty for {Name} ({ComposePath})", name, composePath);
+            return;
+        }
+
+        if (!File.Exists(scriptPath))
+        {
+            _logger.LogError("Hook script not found: {ScriptPath} for {Name}", scriptPath, name);
+            return;
+        }
+
+        _logger.LogInformation("Running post-update hook {ScriptPath} for {Name}", scriptPath, name);
 
         var startInfo = new ProcessStartInfo
         {
@@ -21,7 +33,6 @@ public class HookService
             RedirectStandardError = true
         };
 
-        // Exporting your requested variables
         startInfo.EnvironmentVariables["PP_PROJECT_DIR"] = Path.GetDirectoryName(composePath) ?? string.Empty;
         startInfo.EnvironmentVariables["PP_NAME"] = name;
         startInfo.EnvironmentVariables["PP_OLD_VERSION"] = oldVer;
@@ -29,7 +40,25 @@ public class HookService
         startInfo.EnvironmentVariables["PP_UPDATE_TIME"] = DateTime.UtcNow.ToString("o");
 
         using var process = new Process { StartInfo = startInfo };
+
         process.Start();
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+
         await process.WaitForExitAsync();
+
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+
+        _logger.LogInformation("Hook stdout: {Stdout}", string.IsNullOrWhiteSpace(stdout) ? "(empty)" : stdout);
+
+        if (!string.IsNullOrWhiteSpace(stderr))
+            _logger.LogWarning("Hook stderr: {Stderr}", stderr);
+
+        if (process.ExitCode != 0)
+            _logger.LogError("Hook exited {ExitCode} for {ScriptPath}", process.ExitCode, scriptPath);
+        else
+            _logger.LogInformation("Hook completed successfully ({ScriptPath})", scriptPath);
     }
 }

--- a/PatchPanda.Web/Services/HookServices.cs
+++ b/PatchPanda.Web/Services/HookServices.cs
@@ -8,13 +8,21 @@ public class HookService
 
     public HookService(ILogger<HookService> logger) => _logger = logger;
 
-    public async Task ExecuteHookAsync(string scriptPath, string composePath, string name, string oldVer, string newVer)
+    public async Task ExecuteHookAsync(
+        string scriptPath,
+        string? composePath,
+        string name,
+        string oldVer,
+        string newVer
+    )
     {
-        if (string.IsNullOrEmpty(scriptPath))
+        if (string.IsNullOrWhiteSpace(scriptPath))
         {
             _logger.LogWarning("Hook script path is empty for {Name} ({ComposePath})", name, composePath);
             return;
         }
+
+        scriptPath = scriptPath.Trim();
 
         if (!File.Exists(scriptPath))
         {
@@ -26,14 +34,27 @@ public class HookService
 
         var startInfo = new ProcessStartInfo
         {
-            FileName = "/bin/bash",
-            Arguments = $"-c \"{scriptPath}\"",
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true
         };
 
-        startInfo.EnvironmentVariables["PP_PROJECT_DIR"] = Path.GetDirectoryName(composePath) ?? string.Empty;
+        if (OperatingSystem.IsWindows())
+        {
+            startInfo.FileName = "cmd.exe";
+            startInfo.ArgumentList.Add("/C");
+            startInfo.ArgumentList.Add(scriptPath);
+        }
+        else
+        {
+            startInfo.FileName = "/bin/bash";
+            startInfo.ArgumentList.Add(scriptPath);
+        }
+
+        startInfo.EnvironmentVariables["PP_PROJECT_DIR"] =
+            string.IsNullOrWhiteSpace(composePath)
+                ? string.Empty
+                : Path.GetDirectoryName(composePath) ?? string.Empty;
         startInfo.EnvironmentVariables["PP_NAME"] = name;
         startInfo.EnvironmentVariables["PP_OLD_VERSION"] = oldVer;
         startInfo.EnvironmentVariables["PP_NEW_VERSION"] = newVer;
@@ -46,10 +67,10 @@ public class HookService
         var stdoutTask = process.StandardOutput.ReadToEndAsync();
         var stderrTask = process.StandardError.ReadToEndAsync();
 
-        await process.WaitForExitAsync();
+        await Task.WhenAll(stdoutTask, stderrTask, process.WaitForExitAsync());
 
-        var stdout = await stdoutTask;
-        var stderr = await stderrTask;
+        var stdout = stdoutTask.Result;
+        var stderr = stderrTask.Result;
 
         _logger.LogInformation("Hook stdout: {Stdout}", string.IsNullOrWhiteSpace(stdout) ? "(empty)" : stdout);
 
@@ -57,7 +78,9 @@ public class HookService
             _logger.LogWarning("Hook stderr: {Stderr}", stderr);
 
         if (process.ExitCode != 0)
-            _logger.LogError("Hook exited {ExitCode} for {ScriptPath}", process.ExitCode, scriptPath);
+            throw new InvalidOperationException(
+                $"Hook exited with code {process.ExitCode} for {scriptPath}."
+            );
         else
             _logger.LogInformation("Hook completed successfully ({ScriptPath})", scriptPath);
     }

--- a/PatchPanda.Web/Services/UpdateService.cs
+++ b/PatchPanda.Web/Services/UpdateService.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using PatchPanda.Services;
 
 namespace PatchPanda.Web.Services;
 
@@ -14,6 +15,7 @@ public class UpdateService
     private readonly IVersionService _versionService;
     private readonly JobRegistry _jobRegistry;
     private readonly INotificationService _notificationService;
+    private readonly HookService _hookService;
 
     public UpdateService(
         DockerService dockerService,
@@ -23,7 +25,8 @@ public class UpdateService
         IPortainerService portainerService,
         IVersionService versionService,
         JobRegistry jobRegistry,
-        INotificationService notificationService
+        INotificationService notificationService,
+        HookService hookService
     )
     {
         _dockerService = dockerService;
@@ -34,6 +37,7 @@ public class UpdateService
         _versionService = versionService;
         _jobRegistry = jobRegistry;
         _notificationService = notificationService;
+        _hookService = hookService;
     }
 
     private void CleanUpContainerJobs(int containerId)
@@ -353,10 +357,12 @@ public class UpdateService
             ArgumentNullException.ThrowIfNull(app.GitHubVersionRegex);
             ArgumentNullException.ThrowIfNull(app.Version);
 
+            var oldVersion = app.Version;
+
             await using var db = await _dbContextFactory.CreateDbContextAsync(
-                CancellationToken.None
+                cancellationToken
             );
-            var stack = await db.Stacks.FirstAsync(x => x.Id == app.StackId, CancellationToken.None);
+            var stack = await db.Stacks.FirstAsync(x => x.Id == app.StackId, cancellationToken);
             var configPath = stack.ConfigFile;
 
             if (configPath is null && (!stack.PortainerManaged || !_portainerService.IsConfigured))
@@ -797,6 +803,33 @@ public class UpdateService
                 app.Version,
                 newVersion
             );
+
+            if (!string.IsNullOrWhiteSpace(targetApp.PostUpdateHook))
+            {
+                try
+                {
+                    await _hookService.ExecuteHookAsync(
+                        targetApp.PostUpdateHook,
+                        stack.ConfigFile ?? string.Empty,
+                        targetApp.Name,
+                        oldVersion ?? string.Empty,
+                        newVersion
+                    );
+
+                    _logger.LogInformation(
+                        "Post-update hook executed for container {Container}",
+                        targetApp.Name
+                    );
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "Post-update hook failed for container {Container}",
+                        targetApp.Name
+                    );
+                }
+            }
 
             return new(updateSteps);
         }

--- a/PatchPanda.Web/Services/UpdateService.cs
+++ b/PatchPanda.Web/Services/UpdateService.cs
@@ -806,28 +806,38 @@ public class UpdateService
 
             if (!string.IsNullOrWhiteSpace(targetApp.PostUpdateHook))
             {
-                try
+                if (string.IsNullOrWhiteSpace(stack.ConfigFile))
                 {
-                    await _hookService.ExecuteHookAsync(
-                        targetApp.PostUpdateHook,
-                        stack.ConfigFile ?? string.Empty,
-                        targetApp.Name,
-                        oldVersion ?? string.Empty,
-                        newVersion
-                    );
-
-                    _logger.LogInformation(
-                        "Post-update hook executed for container {Container}",
+                    _logger.LogWarning(
+                        "Skipping post-update hook for container {Container} because compose file path is unavailable (Portainer-managed stack).",
                         targetApp.Name
                     );
                 }
-                catch (Exception ex)
+                else
                 {
-                    _logger.LogError(
-                        ex,
-                        "Post-update hook failed for container {Container}",
-                        targetApp.Name
-                    );
+                    try
+                    {
+                        await _hookService.ExecuteHookAsync(
+                            targetApp.PostUpdateHook,
+                            stack.ConfigFile,
+                            targetApp.Name,
+                            oldVersion ?? string.Empty,
+                            newVersion
+                        );
+
+                        _logger.LogInformation(
+                            "Post-update hook executed for container {Container}",
+                            targetApp.Name
+                        );
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(
+                            ex,
+                            "Post-update hook failed for container {Container}",
+                            targetApp.Name
+                        );
+                    }
                 }
             }
 

--- a/PatchPanda.Web/Services/UpdateService.cs
+++ b/PatchPanda.Web/Services/UpdateService.cs
@@ -821,7 +821,7 @@ public class UpdateService
                             targetApp.PostUpdateHook,
                             stack.ConfigFile,
                             targetApp.Name,
-                            oldVersion ?? string.Empty,
+                            oldVersion,
                             newVersion
                         );
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,9 @@ dotnet ef database update --project PatchPanda.Web --startup-project PatchPanda.
 - Notifications are posted to the configured Discord webhook and Apprise notification URLs. PatchPanda will chunk long messages (Discord limits message length) and mark versions as notified once it posted them.
 
 ## Post-hooks
+
 After a successful update, PatchPanda can execute an optional post-update hook by calling a user-defined script. Define the script path using a Docker label in your `docker-compose.yml`.
+
 ```yaml
 services:
     myservice:
@@ -222,6 +224,7 @@ services:
 ```
 
 PatchPanda sets these variables for your script:
+
 - `PP_PROJECT_DIR`: Directory of the compose file
 - `PP_NAME`: Container name to be updated
 - `PP_OLD_VERSION`: Previous image version
@@ -230,13 +233,16 @@ PatchPanda sets these variables for your script:
 
 Keep in mind the update script runs within the PatchPanda container and not on the host itself. However, you have access to the host file system via volumes
 
+When a stack is managed via Portainer and no local compose path is available, post-update hooks are skipped.
+
 ## Example post-update hook script
+
 ```bash
 #!/bin/bash
-cd $PP_PROJECT_DIR
+cd "$PP_PROJECT_DIR"
 apt-get update
 apt-get install -y git
-git config --global --add safe.directory $PP_PROJECT_DIR
+git config --global --add safe.directory "$PP_PROJECT_DIR"
 git config --global user.email "none@none"
 git config --global user.name "PatchPanda Updater"
 git add docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -211,6 +211,38 @@ dotnet ef database update --project PatchPanda.Web --startup-project PatchPanda.
 
 - Notifications are posted to the configured Discord webhook and Apprise notification URLs. PatchPanda will chunk long messages (Discord limits message length) and mark versions as notified once it posted them.
 
+## Post-hooks
+After a successful update, PatchPanda can execute an optional post-update hook by calling a user-defined script. Define the script path using a Docker label in your `docker-compose.yml`.
+```yaml
+services:
+    myservice:
+        labels:
+        - "patchpanda.hook.post_update=/path/to/script"
+        ...
+```
+
+PatchPanda sets these variables for your script:
+- `PP_PROJECT_DIR`: Directory of the compose file
+- `PP_NAME`: Container name to be updated
+- `PP_OLD_VERSION`: Previous image version
+- `PP_NEW_VERSION`: New image version
+- `PP_UPDATE_TIME`: ISO timestamp of the update
+
+Keep in mind the update script runs within the PatchPanda container and not on the host itself. However, you have access to the host file system via volumes
+
+## Example post-update hook script
+```bash
+#!/bin/bash
+cd $PP_PROJECT_DIR
+apt-get update
+apt-get install -y git
+git config --global --add safe.directory $PP_PROJECT_DIR
+git config --global user.email "none@none"
+git config --global user.name "PatchPanda Updater"
+git add docker-compose.yml
+git commit -m "Update $PP_OLD_VERSION -> $PP_NEW_VERSION"
+```
+
 ## Troubleshooting & tips
 
 - If PatchPanda can't find the GitHub repo to your container, make sure to include it in one of the labels.

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ services:
         ...
 ```
 
+Restart the observed stack with docker compose such that the labels are being read and recheck the containers in the PatchPanda GUI
 PatchPanda sets these variables for your script:
 
 - `PP_PROJECT_DIR`: Directory of the compose file
@@ -246,7 +247,7 @@ git config --global --add safe.directory "$PP_PROJECT_DIR"
 git config --global user.email "none@none"
 git config --global user.name "PatchPanda Updater"
 git add docker-compose.yml
-git commit -m "Update $PP_OLD_VERSION -> $PP_NEW_VERSION"
+git commit -m "PatchPanda update $PP_OLD_VERSION -> $PP_NEW_VERSION"
 ```
 
 ## Troubleshooting & tips


### PR DESCRIPTION
This PR implements a post update hook, which allows to run a script after a successful update. The script is run within the PatchPanda container, but has access to the host filesystem. Sample script:


      #!/bin/bash      
      apt-get update
      apt-get install -y git

      # needed since script is run as root
      git config --global --add safe.directory $PP_PROJECT_DIR

      git config --global user.email "none@none"
      git config --global user.name "PatchPanda Updater"
      
      cd $PP_PROJECT_DIR
      git add docker-compose.yml
      git commit -m "Update $PP_OLD_VERSION -> $PP_NEW_VERSION"


A typical use case includes an automated git commit of the docker-compose.yml. Unfortunately, the current image mcr.microsoft.com/dotnet/aspnet doesn't include git, hence it need to be installed from within the script. In order to simplify post update scripts for the git use-case, the installation of git could be done within the Dockerfile. What do you think?

This PR was created with significant help of Github Copilot

fixes #89 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added post-update hook support to run an optional user script after a successful update.
  * Hooks are read from the Docker label `patchpanda.hook.post_update` and stored per container; if the hook or compose file is missing/blank, the hook is skipped.
  * The hook runs with `PP_PROJECT_DIR`, `PP_NAME`, `PP_OLD_VERSION`, `PP_NEW_VERSION`, and `PP_UPDATE_TIME`. Any hook execution errors are logged without failing the update.

* **Documentation**
  * Added a “Post-hooks” section with configuration details, environment variables, and an example workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->